### PR TITLE
Add minimal LINE Flex designer app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # line-flex-designer
+
+This is a minimal Node.js application that allows you to edit LINE Flex Message templates and broadcast them to a list of LINE user IDs.
+
+## Usage
+
+1. Set `LINE_CHANNEL_ACCESS_TOKEN` environment variable with your LINE channel access token.
+2. Run the server:
+   ```bash
+   node server.js
+   ```
+3. Open `http://localhost:3000` in your browser.
+4. Select a predefined template, adjust the JSON, upload a text/CSV file containing LINE user IDs (one per line), and press **Broadcast**.
+
+The server sends the edited Flex Message individually to each provided user ID via the LINE Messaging API.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>LINE Flex Designer</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 2em; }
+textarea { width: 100%; height: 200px; }
+</style>
+</head>
+<body>
+<h1>LINE Flex Designer</h1>
+<form id="form" enctype="multipart/form-data">
+  <label>Choose Template:</label>
+  <select id="templateSelect">
+    <option value="sample1">Sample 1</option>
+    <option value="sample2">Sample 2</option>
+  </select>
+  <br><br>
+  <label>Edit Template JSON:</label><br>
+  <textarea name="template" id="templateArea"></textarea>
+  <br>
+  <label>Upload User IDs (CSV or text):</label>
+  <input type="file" name="users" id="usersFile" accept=".txt,.csv" />
+  <br><br>
+  <button type="submit">Broadcast</button>
+</form>
+<pre id="result"></pre>
+<script>
+const templates = {
+  sample1: {
+    type: "flex",
+    altText: "Hello",
+    contents: {
+      type: "bubble",
+      body: { type: "box", layout: "vertical", contents: [ { type: "text", text: "Sample1" } ] }
+    }
+  },
+  sample2: {
+    type: "flex",
+    altText: "Hi",
+    contents: {
+      type: "bubble",
+      body: { type: "box", layout: "vertical", contents: [ { type: "text", text: "Sample2" } ] }
+    }
+  }
+};
+function updateTemplate() {
+  const key = document.getElementById('templateSelect').value;
+  document.getElementById('templateArea').value = JSON.stringify(templates[key], null, 2);
+}
+document.getElementById('templateSelect').addEventListener('change', updateTemplate);
+updateTemplate();
+
+const form = document.getElementById('form');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const data = new FormData(form);
+  const res = await fetch('/broadcast', { method: 'POST', body: data });
+  const text = await res.text();
+  document.getElementById('result').textContent = text;
+});
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "line-flex-designer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,129 @@
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const LINE_TOKEN = process.env.LINE_CHANNEL_ACCESS_TOKEN || '';
+
+function sendLineMessage(userId, message) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify({ to: userId, messages: [message] });
+    const options = {
+      hostname: 'api.line.me',
+      path: '/v2/bot/message/push',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${LINE_TOKEN}`,
+        'Content-Length': Buffer.byteLength(data),
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let body = '';
+      res.on('data', (chunk) => body += chunk);
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          resolve(body);
+        } else {
+          reject(new Error(`LINE API error: ${res.statusCode} ${body}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+function parseMultipart(req, boundary, callback) {
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks).toString();
+    const result = {};
+    const parts = body.split('--' + boundary);
+    parts.forEach(part => {
+      if (part.includes('Content-Disposition')) {
+        const nameMatch = part.match(/name="([^"]+)"/);
+        if (!nameMatch) return;
+        const name = nameMatch[1];
+        const start = part.indexOf('\r\n\r\n');
+        if (start === -1) return;
+        const content = part.slice(start + 4, part.lastIndexOf('\r\n'));
+        result[name] = content;
+      }
+    });
+    callback(null, result);
+  });
+}
+
+function serveIndex(res) {
+  fs.readFile(path.join(__dirname, 'index.html'), (err, data) => {
+    if (err) {
+      res.writeHead(500);
+      res.end('Server error');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/') {
+    serveIndex(res);
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/broadcast') {
+    const contentType = req.headers['content-type'] || '';
+    const match = contentType.match(/boundary=(.+)$/);
+    if (!match) {
+      res.writeHead(400);
+      res.end('Invalid request');
+      return;
+    }
+    const boundary = match[1];
+    parseMultipart(req, boundary, async (err, fields) => {
+      if (err) {
+        res.writeHead(500);
+        res.end('Error parsing form');
+        return;
+      }
+      let users = [];
+      if (fields.users) {
+        users = fields.users.split(/\r?\n/).map(u => u.trim()).filter(Boolean);
+      }
+      let template;
+      try {
+        template = JSON.parse(fields.template || '{}');
+      } catch (e) {
+        res.writeHead(400);
+        res.end('Invalid JSON template');
+        return;
+      }
+      const results = [];
+      for (const id of users) {
+        try {
+          await sendLineMessage(id, template);
+          results.push(`${id}: ok`);
+        } catch (e) {
+          results.push(`${id}: ${e.message}`);
+        }
+      }
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(results.join('\n'));
+    });
+    return;
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create a simple Node.js server (no external deps) to send LINE flex messages
- add `index.html` UI for choosing/editing templates and uploading user ID lists
- document how to run the tool in `README`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846ce4068f083208f6af9c753526160