### PR TITLE
Improve README with project overview and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,55 @@
-# line-flex-designer
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/README.md b/README.md
-index dbcd9b0c907f3c63e9faaefb06de13882b03a380..864b9bbad9fb143c936831cfcf18ba943ae3dc7b 100644
---- a/README.md
-+++ b/README.md
-@@ -1 +1,55 @@
--# line-flex-designer
-\ No newline at end of file
-+# Line Flex Designer
-+
-+Line Flex Designer is a project aimed at providing a flexible and modern web-based design environment. It pairs a Node.js backend with an Angular frontend so you can create, manage and preview designs easily.
-+
-+## Stack Overview
-+
-+- **Backend:** Node.js (we recommend using [Express](https://expressjs.com/) for routing and middleware)
-+- **Frontend:** [Angular v20](https://angular.io/)
-+- **Database:** [MariaDB](https://mariadb.org/)
-+
-+## Getting Started
-+
-+### Prerequisites
-+
-+Ensure you have the following installed:
-+
-+- [Node.js](https://nodejs.org/) 18 or later
-+- [Angular CLI](https://angular.io/cli) matching version 20
-+- [MariaDB](https://mariadb.org/) server
-+
-+### Install Dependencies
-+
-+From the project root, install the backend and frontend packages. If these live in separate folders, adjust the paths accordingly.
-+
-+```bash
-+npm install          # install server dependencies
-+cd client && npm install  # install Angular client dependencies
-+cd ..
-+```
-+
-+### Running the Server
-+
-+To start the backend (assuming it is an Express application):
-+
-+```bash
-+npm start
-+```
-+
-+### Running the Client
-+
-+From the `client` directory run:
-+
-+```bash
-+ng serve
-+```
-+
-+Then open your browser to the URL shown in the Angular CLI output, usually `http://localhost:4200/`.
-+
-+## Contributing
-+
-+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
-+
-+## License
-+
-+MIT
- 
-EOF
-)
+# Line Flex Designer
+
+Line Flex Designer is a web-based project for creating and previewing flexible design layouts. It couples a Node.js backend with an Angular frontend so you can manage designs from any modern browser.
+
+## Stack Overview
+
+- **Backend:** Node.js (with [Express](https://expressjs.com/) suggested for routing and middleware)
+- **Frontend:** [Angular v20](https://angular.io/)
+- **Database:** [MariaDB](https://mariadb.org/)
+
+## Getting Started
+
+### Prerequisites
+
+Make sure you have the following installed:
+
+- [Node.js](https://nodejs.org/) 18 or later
+- [Angular CLI](https://angular.io/cli) v20
+- [MariaDB](https://mariadb.org/) server
+
+### Install Dependencies
+
+From the project root, install the server and client dependencies. If the Angular client resides in a `client` folder (adjust if different):
+
+```bash
+npm install               # install server dependencies
+cd client && npm install  # install Angular client dependencies
+cd ..
+```
+
+### Running the Server
+
+Start the backend (assuming an Express application):
+
+```bash
+npm start
+```
+
+### Running the Client
+
+From the `client` directory run:
+
+```bash
+ng serve
+```
+
+Then open your browser to the URL shown in the CLI output, usually `http://localhost:4200/`.
+
+## Contributing
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- clean up README and add a brief description of the project
- document the stack (Node.js/Express backend, Angular v20 frontend, MariaDB database)
- add instructions for installing dependencies and running the server and client

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6846d40c3090832095183c624c08907a