### PR TITLE
Add basic broadcast page and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Line Flex Designer
 
-Line Flex Designer is a web-based project for creating and previewing flexible design layouts. It couples a Node.js backend with an Angular frontend so you can manage designs from any modern browser.
+Line Flex Designer is a web-based project for creating and previewing flexible design layouts. It couples a Node.js backend with a web frontend so you can manage designs from any modern browser. The initial frontend is a simple static page that lets you craft broadcast messages, but it can be expanded with Angular in the future.
 
 ## Stack Overview
 
 - **Backend:** Node.js (with [Express](https://expressjs.com/) suggested for routing and middleware)
-- **Frontend:** [Angular v20](https://angular.io/)
+- **Frontend:** Static HTML/JS (Angular can be added later)
 - **Database:** [MariaDB](https://mariadb.org/)
 
 ## Code Structure
@@ -13,11 +13,11 @@ Line Flex Designer is a web-based project for creating and previewing flexible d
 ```
 line-flex-designer/
 ├── server/   # Node.js + Express backend
-├── client/   # Angular v20 frontend
+├── client/   # Static frontend files (initial broadcast page)
 └── README.md
 ```
 
-The **server** directory contains the Node.js backend. The **client** directory holds the Angular code. Project docs like this README live at the root.
+The **server** directory contains the Node.js backend. The **client** directory holds the static broadcast page (and can later host an Angular app). Project docs like this README live at the root.
 
 ## Getting Started
 
@@ -26,7 +26,6 @@ Verify that your local tools can run before installing dependencies:
 
 ```bash
 node -v        # check Node.js
-ng version     # check Angular CLI
 mysql -u <user> -p -e "SELECT VERSION();"  # verify MariaDB access
 ```
 
@@ -37,7 +36,6 @@ Create any required environment files (e.g., `.env`) with your database credenti
 Make sure you have the following installed:
 
 - [Node.js](https://nodejs.org/) 18 or later
-- [Angular CLI](https://angular.io/cli) v20
 - [MariaDB](https://mariadb.org/) server
 
 ### Install Dependencies
@@ -45,9 +43,7 @@ Make sure you have the following installed:
 From the project root, install the server and client dependencies. If the Angular client resides in a `client` folder (adjust if different):
 
 ```bash
-npm install               # install server dependencies
-cd client && npm install  # install Angular client dependencies
-cd ..
+cd server && npm install  # install server dependencies
 ```
 
 ### Running the Server
@@ -60,13 +56,7 @@ npm start
 
 ### Running the Client
 
-From the `client` directory run:
-
-```bash
-ng serve
-```
-
-Then open your browser to the URL shown in the CLI output, usually `http://localhost:4200/`.
+The server also serves the static client files. After starting the server, open your browser to `http://localhost:3000/` to access the broadcast page.
 
 ## Contributing
 

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Broadcast Flex Message</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    textarea { width: 100%; height: 200px; }
+    #preview { white-space: pre; border: 1px solid #ccc; padding: 10px; margin-top: 10px; }
+    button { margin-right: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Broadcast Flex Message</h1>
+  <textarea id="flex-input" placeholder="Enter Flex Message JSON here"></textarea>
+  <div>
+    <button onclick="preview()">Preview</button>
+    <button onclick="broadcast()">Broadcast</button>
+  </div>
+  <h2>Preview</h2>
+  <div id="preview"></div>
+
+  <script>
+    function preview() {
+      const input = document.getElementById('flex-input').value;
+      try {
+        const json = JSON.parse(input);
+        document.getElementById('preview').textContent = JSON.stringify(json, null, 2);
+      } catch (e) {
+        document.getElementById('preview').textContent = 'Invalid JSON';
+      }
+    }
+
+    async function broadcast() {
+      const input = document.getElementById('flex-input').value;
+      try {
+        const payload = JSON.parse(input);
+        const res = await fetch('/broadcast', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const result = await res.json();
+        alert('Broadcast status: ' + result.status);
+      } catch (e) {
+        alert('Invalid JSON or network error');
+      }
+    }
+  </script>
+</body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, '../client')));
+
+app.post('/broadcast', (req, res) => {
+  const message = req.body;
+  console.log('Broadcasting message:', JSON.stringify(message, null, 2));
+  // Integration with LINE OA API would go here.
+  res.json({ status: 'ok' });
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "line-flex-designer-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- implement a minimal Express server under `server/`
- add static broadcast page under `client/`
- document how to run the server and access the page

## Testing
- `node server/index.js` *(fails: Cannot find module 'express')*
- `npm install` in `server` *(no output due to restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_6846f4bc95fc83209606a89f6eb52662